### PR TITLE
Correct typo about manually setting AWS credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ npm install aws-s3-promisified
 ```
 
 ###Usage:
-#####Option 1: environmental variables. 
+#####Option 1: environmental variables.
 Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY as environment variables, then Node will configure AWS automatically.
 ```
 var aws = require('aws-s3-promisified');
 ```
 #####Option 2: set environment variables manually
 ```
-var aws = require('aws-s3-promisified').initialize(AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY);
+var aws = require('aws-s3-promisified').initialize(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY);
 ```
 
 All these functions return a Bluebird promise.


### PR DESCRIPTION
initialize takes 2 string arguments, not 1 boolean argument.
