### PR TITLE
Allow getSignedURL options to pass through

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,25 +59,18 @@ var saveObjectToFile = function (bucket, key, path) {
 
 var getSignedURL = function (bucket, key, options) {
   var s3 = new AWS.S3();
-  var params = {
+  options = options || {};
+
+  var params = _.extend(options, {
     Bucket: bucket,
     Key: key,
     Expires: this.getExpirationInSeconds()
-  };
+  });
 
-  options = options || {};
   var operation = options.operation || 'getObject';
 
   if (options.contentType) {
     params.ContentType = options.contentType;
-  }
-
-  if (options.ACL) {
-    params.ACL = options.ACL;
-  }
-
-  if (options.ResponseContentDisposition) {
-    params.ResponseContentDisposition = options.ResponseContentDisposition;
   }
 
   return new BluebirdPromise(function (resolve, reject) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "aws-s3-promisified",
+  "name": "@mapistry/aws-s3-promisified",
   "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -35,9 +35,9 @@
       "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "commander": {
@@ -89,7 +89,7 @@
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
-        "samsam": "1.1.2"
+        "samsam": "~1.1"
       }
     },
     "glob": {
@@ -98,8 +98,8 @@
       "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimatch": "0.3.0"
+        "inherits": "2",
+        "minimatch": "0.3"
       }
     },
     "growl": {
@@ -177,8 +177,8 @@
       "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.7.3",
-        "sigmund": "1.0.1"
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
       }
     },
     "minimist": {
@@ -260,8 +260,8 @@
           "integrity": "sha1-Ek/EEUtBKcgQgA7LKshs8lRiy5o=",
           "dev": true,
           "requires": {
-            "sax": "0.5.8",
-            "xmlbuilder": "9.0.7"
+            "sax": "0.5.x",
+            "xmlbuilder": ">=0.4.2"
           }
         }
       }
@@ -292,7 +292,7 @@
         "formatio": "1.1.1",
         "lolex": "1.3.2",
         "samsam": "1.1.2",
-        "util": "0.11.1"
+        "util": ">=0.10.3 <1"
       }
     },
     "supports-color": {
@@ -340,8 +340,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": "1.2.1",
-        "xmlbuilder": "9.0.7"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {


### PR DESCRIPTION
I needed to add `ResponseCacheControl: "no-cache"` to `getSignedURL` so we can "edit" images. The way I changed it allows us to add any options to `getSignedURL` without having to crack this method open again.